### PR TITLE
Don't fragment memcache get commands with a single key, raise some event loglevels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2021-04-09 Tyson Andre
+	  Raise the severity of establishing connections, connection errors and pool update logs to
+	  LOG_NOTICE (tyson)
+	  Fix memory corruption seen when all hosts are ejected from a pool with
+	  auto_eject_hosts: true (tyson)
+	  Update tests to work with python 3 (tyson)
+	  Ensure file permissions aren't chosen based on uninitialized memory. (tyson)
+	  Add a heartbeat patch to detect dead servers (charsyam)
+	  Decrease the verbosity of logging clients establishing/closing connections to
+	  nutcracker to LOG_INFO for use cases that can't support persistent connections (tyson)
+	  Micro-optimization: Don't fragment memcache multigets with a single key
+	  into an array of commands to coalesce. (tyson)
+
 2016-04-27  Misha Nasledov <misha@nasledov.com>
     * twemproxy: version 0.5.1 release
       updated to latest master from twitter/twemproxy

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -208,7 +208,7 @@ core_send(struct context *ctx, struct conn *conn)
 
     status = conn->send(ctx, conn);
     if (status != NC_OK) {
-        log_debug(LOG_INFO, "send on %c %d failed: status: %d errno: %d %s",
+        log_debug(LOG_NOTICE, "send on %c %d failed: status: %d errno: %d %s",
                   conn->client ? 'c' : (conn->proxy ? 'p' : 's'), conn->sd,
                   status, errno, strerror(errno));
     }

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -322,7 +322,7 @@ server_failure(struct context *ctx, struct server *server)
 
     next = now + pool->server_retry_timeout;
 
-    log_debug(LOG_INFO, "update pool %"PRIu32" '%.*s' to delete server '%.*s' "
+    log_debug(LOG_NOTICE, "update pool %"PRIu32" '%.*s' to delete server '%.*s' "
               "for next %"PRIu32" secs", pool->idx, pool->name.len,
               pool->name.data, server->pname.len, server->pname.data,
               pool->server_retry_timeout / 1000 / 1000);
@@ -423,7 +423,7 @@ server_close(struct context *ctx, struct conn *conn)
                 event_add_out(ctx->evb, msg->owner);
             }
 
-            log_debug(LOG_INFO, "close s %d schedule error for req %"PRIu64" "
+            log_debug(LOG_NOTICE, "close s %d schedule error for req %"PRIu64" "
                       "len %"PRIu32" type %d from c %d%c %s", conn->sd, msg->id,
                       msg->mlen, msg->type, c_conn->sd, conn->err ? ':' : ' ',
                       conn->err ? strerror(conn->err): " ");
@@ -456,7 +456,7 @@ server_close(struct context *ctx, struct conn *conn)
                 event_add_out(ctx->evb, msg->owner);
             }
 
-            log_debug(LOG_INFO, "close s %d schedule error for req %"PRIu64" "
+            log_debug(LOG_NOTICE, "close s %d schedule error for req %"PRIu64" "
                       "len %"PRIu32" type %d from c %d%c %s", conn->sd, msg->id,
                       msg->mlen, msg->type, c_conn->sd, conn->err ? ':' : ' ',
                       conn->err ? strerror(conn->err): " ");
@@ -473,7 +473,7 @@ server_close(struct context *ctx, struct conn *conn)
 
         rsp_put(msg);
 
-        log_debug(LOG_INFO, "close s %d discarding rsp %"PRIu64" len %"PRIu32" "
+        log_debug(LOG_NOTICE, "close s %d discarding rsp %"PRIu64" len %"PRIu32" "
                   "in error", conn->sd, msg->id, msg->mlen);
     }
 
@@ -690,7 +690,7 @@ server_switch(struct context *ctx, struct server *server,
     if (status != NC_OK) {
         return status;
     }
-    
+
     /* if the address is the same, return */
     if (!string_compare(&server->pname, &pname)) {
         string_deinit(&pname);
@@ -780,7 +780,7 @@ server_pool_update(struct server_pool *pool)
         return status;
     }
 
-    log_debug(LOG_INFO, "update pool %"PRIu32" '%.*s' to add %"PRIu32" servers",
+    log_debug(LOG_NOTICE, "update pool %"PRIu32" '%.*s' to add %"PRIu32" servers",
               pool->idx, pool->name.len, pool->name.data,
               pool->nlive_server - pnlive_server);
 

--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -89,6 +89,33 @@ memcache_retrieval(struct msg *r)
 }
 
 /*
+ * Return true, if the memcache command should be fragmented,
+ * otherwise return false.
+ *
+ * The only supported memcache commands that can have multiple keys
+ * are get/gets. Both are multigets, and the latter returns CAS token with the value.
+ *
+ * Fragmented requests are assumed to be slower due to the fact that they need to allocate
+ * an array to track which key went to which server, so avoid them when possible.
+ */
+static bool
+memcache_should_fragment(struct msg *r)
+{
+    switch (r->type) {
+    case MSG_REQ_MC_GET:
+    case MSG_REQ_MC_GETS:
+        // A memcache get for a single key is only sent to one server.
+        // Fragmenting it would work but be less efficient.
+        return array_n(r->keys) != 1;
+
+    default:
+        break;
+    }
+
+    return false;
+}
+
+/*
  * Return true, if the memcache command is a arithmetic command, otherwise
  * return false
  */
@@ -1338,7 +1365,7 @@ memcache_fragment_retrieval(struct msg *r, uint32_t nservers,
 rstatus_t
 memcache_fragment(struct msg *r, uint32_t nservers, struct msg_tqh *frag_msgq)
 {
-    if (memcache_retrieval(r)) {
+    if (memcache_should_fragment(r)) {
         return memcache_fragment_retrieval(r, nservers, frag_msgq, 1);
     }
     return NC_OK;


### PR DESCRIPTION
Fragmenting memcache gets would involve splitting up the request into multiple smaller
requests and concatenating strings to rebuild the original request.

Closes https://github.com/ifwe/twemproxy/issues/24

Raise log severity of connection errors and pool updates
    
This will log at `-v 5`(LOG_NOTICE)
whenever a client disconnects before receiving a response,
whenever a memcache server is added or removed from a pool with
auto_eject_hosts, etc.

Previously, those events were at LOG_INFO, which logged every single
successfully performed memcached command (e.g. memcached get),
which was too verbose to use except for debugging.
    
Knowing if hosts were ejected from the pool is useful for diagnosing
memcached issues or bugs.
