### PR TITLE
Add C unit testing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # pyc
 *.pyc
 
+# Unit tests
+src/test_all
+*.trs
+
 # Compiled Object files
 *.lo
 *.o

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ A quick checklist:
 + Use CFLAGS="-O3 -fno-strict-aliasing" ./configure && make
 + `autoreconf -fvi && ./configure` needs `automake` and `libtool` to be installed
 
+## Testing
+
+See [tests/README.rst](tests/README.rst) for the more extensive integration tests written in python and nosetests.
+
+If you want to unit test a C function, see the unit tests in the `src` folder. A tiny number of test cases exist that can be run with `make check` (`test_all.c`).
+
 ## Features
 
 + Fast.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,3 +59,32 @@ nutredis_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
 nutredis_LDADD += $(top_builddir)/src/proto/libproto.a
 nutredis_LDADD += $(top_builddir)/src/event/libevent.a
 nutredis_LDADD += $(top_builddir)/contrib/yaml-0.1.4/src/.libs/libyaml.a
+
+TESTS = test_all
+bin_PROGRAMS = test_all
+
+test_all_SOURCES = test_all.c \
+	nc_core.c nc_core.h		\
+	nc_connection.c nc_connection.h	\
+	nc_client.c nc_client.h		\
+	nc_server.c nc_server.h		\
+	nc_sentinel.c nc_sentinel.h	\
+	nc_proxy.c nc_proxy.h		\
+	nc_message.c nc_message.h	\
+	nc_request.c			\
+	nc_response.c			\
+	nc_mbuf.c nc_mbuf.h		\
+	nc_conf.c nc_conf.h		\
+	nc_stats.c nc_stats.h		\
+	nc_signal.c nc_signal.h		\
+	nc_rbtree.c nc_rbtree.h		\
+	nc_log.c nc_log.h		\
+	nc_string.c nc_string.h		\
+	nc_array.c nc_array.h		\
+	nc_util.c nc_util.h		\
+	nc_queue.h
+
+test_all_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
+test_all_LDADD += $(top_builddir)/src/proto/libproto.a
+test_all_LDADD += $(top_builddir)/src/event/libevent.a
+test_all_LDADD += $(top_builddir)/contrib/yaml-0.1.4/src/.libs/libyaml.a

--- a/src/hashkit/nc_hashkit.h
+++ b/src/hashkit/nc_hashkit.h
@@ -74,5 +74,6 @@ rstatus_t modula_update(struct server_pool *pool);
 uint32_t modula_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
 rstatus_t random_update(struct server_pool *pool);
 uint32_t random_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
+uint32_t ketama_hash(const char *key, size_t key_length, uint32_t alignment);
 
 #endif

--- a/src/hashkit/nc_ketama.c
+++ b/src/hashkit/nc_ketama.c
@@ -27,7 +27,7 @@
 #define KETAMA_POINTS_PER_SERVER    160 /* 40 points per hash */
 #define KETAMA_MAX_HOSTLEN          86
 
-static uint32_t
+uint32_t
 ketama_hash(const char *key, size_t key_length, uint32_t alignment)
 {
     unsigned char results[16];

--- a/src/test_all.c
+++ b/src/test_all.c
@@ -19,6 +19,8 @@ static void test_hash_algorithms(void) {
     // refer to libmemcached tests/hash_results.h
     expect_same_uint32_t(2297466611U, hash_one_at_a_time("apple", 5), "should have expected one_at_a_time hash for key \"apple\"");
     expect_same_uint32_t(3195025439U, hash_md5("apple", 5), "should have expected md5 hash for key \"apple\"");
+    expect_same_uint32_t(3853726576U, ketama_hash("server1-8", strlen("server1-8"), 0), "should have expected ketama_hash for server1-8 index 0");
+    expect_same_uint32_t(2667054752U, ketama_hash("server1-8", strlen("server1-8"), 3), "should have expected ketama_hash for server1-8 index 3");
 }
 
 static void test_config_parsing(void) {

--- a/src/test_all.c
+++ b/src/test_all.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <nc_hashkit.h>
+#include <nc_conf.h>
+
+static int failures = 0;
+static int successes = 0;
+
+static void expect_same_uint32_t(uint32_t expected, uint32_t actual, const char* message) {
+    if (expected != actual) {
+        printf("FAIL Expected %u, got %u (%s)\n", (unsigned int) expected, (unsigned int) actual, message);
+        failures++;
+    } else {
+        printf("PASS (%s)\n", message);
+        successes++;
+    }
+}
+
+static void test_hash_algorithms(void) {
+    // refer to libmemcached tests/hash_results.h
+    expect_same_uint32_t(2297466611U, hash_one_at_a_time("apple", 5), "should have expected one_at_a_time hash for key \"apple\"");
+    expect_same_uint32_t(3195025439U, hash_md5("apple", 5), "should have expected md5 hash for key \"apple\"");
+}
+
+static void test_config_parsing(void) {
+    char* conf_file = "../conf/nutcracker.yml";
+    struct conf * conf = conf_create(conf_file);
+    if (conf == NULL) {
+        printf("FAIL could not parse %s\n", conf_file);
+        failures++;
+    } else {
+        printf("PASS parsed %s\n", conf_file);
+
+        conf_destroy(conf);
+        successes++;
+    }
+}
+
+int main(int argc, char **argv) {
+    test_hash_algorithms();
+    test_config_parsing();
+    printf("%d successes, %d failures\n", successes, failures);
+    return failures > 0 ? 1 : 0;
+}


### PR DESCRIPTION
This ability is useful for cases such as validating compatibility with
libmemcached, or in directly testing text protocol handling for
memcached/redis/sentinel requests/responses.
Integration tests only test this indirectly, making some edge cases harder to test

Closes https://github.com/ifwe/twemproxy/issues/11