### PR TITLE
Avoid sending heartbeat multiple times or reconnecting multiple times

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,9 @@
 	  Don't bother computing hash or looking up in distribution when a pool
 	  has only one server - the result will always be the same (tyson)
 	  Fix parsing bug when a redis error body contains no spaces (tyson)
+	  Ignore server_failure_limit and treat it as if it's always 1 - the heartbeat
+	  patch is responsible for reconnecting after a server failure.
+	  Don't send more than one heartbeat request when reconnecting to a server.
 
 2016-04-27  Misha Nasledov <misha@nasledov.com>
     * twemproxy: version 0.5.1 release

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,8 +27,9 @@
 	  has only one server - the result will always be the same (tyson)
 	  Fix parsing bug when a redis error body contains no spaces (tyson)
 	  Ignore server_failure_limit and treat it as if it's always 1 - the heartbeat
-	  patch is responsible for reconnecting after a server failure.
-	  Don't send more than one heartbeat request when reconnecting to a server.
+	  patch is responsible for reconnecting after a server failure. (tyson)
+	  Don't send more than one heartbeat request over a single connection to a
+	  server when reconnecting to a server. Reduce concurrent reconnection attempts. (tyson)
 
 2016-04-27  Misha Nasledov <misha@nasledov.com>
     * twemproxy: version 0.5.1 release

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Twemproxy can be configured through a YAML file specified by the -c or --conf-fi
 + **server_connections**: The maximum number of connections that can be opened to each server. By default, we open at most 1 server connection.
 + **auto_eject_hosts**: A boolean value that controls if server should be ejected temporarily when it fails consecutively server_failure_limit times. See [liveness recommendations](notes/recommendation.md#liveness) for information. Defaults to false.
 + **server_retry_timeout**: The timeout value in msec to wait for before retrying on a temporarily ejected server, when auto_eject_host is set to true. Defaults to 30000 msec.
-+ **server_failure_limit**: The number of consecutive failures on a server that would lead to it being temporarily ejected when auto_eject_host is set to true. Defaults to 2. (unused with heartbeat)
++ **server_failure_limit**: ignored
 + **servers**: A list of server address, port and weight (name:port:weight or ip:port:weight) for this server pool.
 + **sentinels**: A list of redis sentinel address, port and weight (name:port:weight or ip:port:weight) for this server pool. Weight of sentinel is not used. If this setting is used, twemproxy will attempt to overwrite its config file when sentinels notify twemproxy that a redis server has failed over to a different server.
 + **failover**: The name of a pool to use instead when a host for a key in this pool is down. This is intended for use with memcache and `auto_eject_hosts: false`. See [notes/failover.md](notes/failover.md) for details

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Twemproxy can be configured through a YAML file specified by the -c or --conf-fi
 + **server_connections**: The maximum number of connections that can be opened to each server. By default, we open at most 1 server connection.
 + **auto_eject_hosts**: A boolean value that controls if server should be ejected temporarily when it fails consecutively server_failure_limit times. See [liveness recommendations](notes/recommendation.md#liveness) for information. Defaults to false.
 + **server_retry_timeout**: The timeout value in msec to wait for before retrying on a temporarily ejected server, when auto_eject_host is set to true. Defaults to 30000 msec.
-+ **server_failure_limit**: The number of consecutive failures on a server that would lead to it being temporarily ejected when auto_eject_host is set to true. Defaults to 2.
++ **server_failure_limit**: The number of consecutive failures on a server that would lead to it being temporarily ejected when auto_eject_host is set to true. Defaults to 2. (unused with heartbeat)
 + **servers**: A list of server address, port and weight (name:port:weight or ip:port:weight) for this server pool.
 + **sentinels**: A list of redis sentinel address, port and weight (name:port:weight or ip:port:weight) for this server pool. Weight of sentinel is not used. If this setting is used, twemproxy will attempt to overwrite its config file when sentinels notify twemproxy that a redis server has failed over to a different server.
 + **failover**: The name of a pool to use instead when a host for a key in this pool is down. This is intended for use with memcache and `auto_eject_hosts: false`. See [notes/failover.md](notes/failover.md) for details

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ m4_define([NC_MAJOR], 0)
 m4_define([NC_MINOR], 5)
 m4_define([NC_PATCH], 2)
 # Indicate in the version string that this is from the ifwe/twemproxy fork to avoid confusion in bug reports, etc.
-m4_define([NC_ITERATION], ifwe18)
+m4_define([NC_ITERATION], ifwe19)
 m4_define([NC_BUGS], [manj@cs.stanford.edu])
 
 # Initialize autoconf

--- a/notes/recommendation.md
+++ b/notes/recommendation.md
@@ -32,6 +32,8 @@ Failures are a fact of life, especially when things are distributed. To be resil
       server_retry_timeout: 30000
       server_failure_limit: 3
 
+NOTE: server_failure_limit is ignored with the heartbeat patch.
+
 Enabling `auto_eject_hosts:` ensures that a dead server can be ejected out of the hash ring after `server_failure_limit:` consecutive failures have been encountered on that said server. A non-zero `server_retry_timeout:` ensures that we don't incorrectly mark a server as dead forever especially when the failures were really transient. The combination of `server_retry_timeout:` and `server_failure_limit:` controls the tradeoff between resiliency to permanent and transient failures.
 
 - **NOTE: The heartbeat patch changes this behavior from the upstream for pools configured with `auto_eject_hosts: true`.** See [heartbeat.md](./heartbeat.md)

--- a/src/hashkit/nc_hashkit.h
+++ b/src/hashkit/nc_hashkit.h
@@ -76,4 +76,8 @@ rstatus_t random_update(struct server_pool *pool);
 uint32_t random_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
 uint32_t ketama_hash(const char *key, size_t key_length, uint32_t alignment);
 
+static inline bool should_keep_server_in_pool(struct server_pool *pool, struct server *server) {
+    return !pool->auto_eject_hosts || server->fail == FAIL_STATUS_NORMAL;
+}
+
 #endif

--- a/src/hashkit/nc_ketama.c
+++ b/src/hashkit/nc_ketama.c
@@ -85,7 +85,6 @@ ketama_update(struct server_pool *pool)
     nserver = array_n(&pool->server);
     nlive_server = 0;
     total_weight = 0;
-    pool->next_rebuild = 0LL;
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);
 

--- a/src/hashkit/nc_ketama.c
+++ b/src/hashkit/nc_ketama.c
@@ -88,18 +88,11 @@ ketama_update(struct server_pool *pool)
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);
 
-        if (pool->auto_eject_hosts) {
-            if (server->fail == FAIL_STATUS_NORMAL) {
-                nlive_server++;
-            }
-        } else {
-            nlive_server++;
-        }
-
         ASSERT(server->weight > 0);
 
         /* count weight only for live servers */
-        if (!pool->auto_eject_hosts || server->fail == FAIL_STATUS_NORMAL) {
+        if (should_keep_server_in_pool(pool, server)) {
+            nlive_server++;
             total_weight += server->weight;
         }
     }
@@ -149,7 +142,7 @@ ketama_update(struct server_pool *pool)
 
         server = array_get_known_type(&pool->server, server_index, struct server);
 
-        if (pool->auto_eject_hosts && server->fail != FAIL_STATUS_NORMAL) {
+        if (!should_keep_server_in_pool(pool, server)) {
             continue;
         }
 

--- a/src/hashkit/nc_ketama.c
+++ b/src/hashkit/nc_ketama.c
@@ -105,7 +105,7 @@ ketama_update(struct server_pool *pool)
 
         return NC_OK;
     }
-    log_debug(LOG_DEBUG, "%"PRIu32" of %"PRIu32" servers are live for pool "
+    log_debug(LOG_NOTICE, "ketama_update: %"PRIu32" of %"PRIu32" servers are live for pool "
               "%"PRIu32" '%.*s'", nlive_server, nserver, pool->idx,
               pool->name.len, pool->name.data);
 

--- a/src/hashkit/nc_modula.c
+++ b/src/hashkit/nc_modula.c
@@ -48,7 +48,6 @@ modula_update(struct server_pool *pool)
     nserver = array_n(&pool->server);
     nlive_server = 0;
     total_weight = 0;
-    pool->next_rebuild = 0LL;
 
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);

--- a/src/hashkit/nc_modula.c
+++ b/src/hashkit/nc_modula.c
@@ -52,18 +52,11 @@ modula_update(struct server_pool *pool)
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);
 
-        if (pool->auto_eject_hosts) {
-            if (server->fail == FAIL_STATUS_NORMAL) {
-                nlive_server++;
-            }
-        } else {
-            nlive_server++;
-        }
-
         ASSERT(server->weight > 0);
 
         /* count weight only for live servers */
-        if (!pool->auto_eject_hosts || server->fail == FAIL_STATUS_NORMAL) {
+        if (should_keep_server_in_pool(pool, server)) {
+            nlive_server++;
             total_weight += server->weight;
         }
     }
@@ -111,7 +104,7 @@ modula_update(struct server_pool *pool)
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);
 
-        if (pool->auto_eject_hosts && server->fail != FAIL_STATUS_NORMAL) {
+        if (!should_keep_server_in_pool(pool, server)) {
             continue;
         }
 

--- a/src/hashkit/nc_modula.c
+++ b/src/hashkit/nc_modula.c
@@ -72,7 +72,7 @@ modula_update(struct server_pool *pool)
 
         return NC_OK;
     }
-    log_debug(LOG_DEBUG, "%"PRIu32" of %"PRIu32" servers are live for pool "
+    log_debug(LOG_NOTICE, "modula_update: %"PRIu32" of %"PRIu32" servers are live for pool "
               "%"PRIu32" '%.*s'", nlive_server, nserver, pool->idx,
               pool->name.len, pool->name.data);
 

--- a/src/hashkit/nc_random.c
+++ b/src/hashkit/nc_random.c
@@ -45,7 +45,6 @@ random_update(struct server_pool *pool)
 
     nserver = array_n(&pool->server);
     nlive_server = 0;
-    pool->next_rebuild = 0LL;
 
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);

--- a/src/hashkit/nc_random.c
+++ b/src/hashkit/nc_random.c
@@ -49,11 +49,7 @@ random_update(struct server_pool *pool)
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);
 
-        if (pool->auto_eject_hosts) {
-            if (server->fail == FAIL_STATUS_NORMAL) {
-                nlive_server++;
-            }
-        } else {
+        if (should_keep_server_in_pool(pool, server)) {
             nlive_server++;
         }
     }
@@ -103,7 +99,7 @@ random_update(struct server_pool *pool)
     for (server_index = 0; server_index < nserver; server_index++) {
         struct server *server = array_get_known_type(&pool->server, server_index, struct server);
 
-        if (pool->auto_eject_hosts && server->fail != FAIL_STATUS_NORMAL) {
+        if (!should_keep_server_in_pool(pool, server)) {
             continue;
         }
 

--- a/src/hashkit/nc_random.c
+++ b/src/hashkit/nc_random.c
@@ -65,7 +65,7 @@ random_update(struct server_pool *pool)
 
         return NC_OK;
     }
-    log_debug(LOG_DEBUG, "%"PRIu32" of %"PRIu32" servers are live for pool "
+    log_debug(LOG_NOTICE, "random_update: %"PRIu32" of %"PRIu32" servers are live for pool "
               "%"PRIu32" '%.*s'", nlive_server, nserver, pool->idx,
               pool->name.len, pool->name.data);
 

--- a/src/nc_array.c
+++ b/src/nc_array.c
@@ -79,9 +79,9 @@ array_deinit(struct array *a)
 }
 
 uint32_t
-array_idx(struct array *a, void *elem)
+array_idx(const struct array *a, const void *elem)
 {
-    uint8_t *p, *q;
+    const uint8_t *p, *q;
     uint32_t off, idx;
 
     ASSERT(elem >= a->elem);
@@ -136,7 +136,7 @@ array_pop(struct array *a)
 }
 
 void *
-array_top(struct array *a)
+array_top(const struct array *a)
 {
     ASSERT(a->nelem != 0);
 
@@ -144,7 +144,7 @@ array_top(struct array *a)
 }
 
 void *
-array_get(struct array *a, uint32_t idx)
+array_get(const struct array *a, uint32_t idx)
 {
     void *elem;
 

--- a/src/nc_array.h
+++ b/src/nc_array.h
@@ -62,7 +62,7 @@ array_n(const struct array *a)
 #define array_get_known_type(a, idx, type) ((type *)array_get_known_element_size((a), (idx), sizeof(type)))
 
 static inline void *
-array_get_known_element_size(struct array *a, uint32_t idx, size_t size)
+array_get_known_element_size(const struct array *a, uint32_t idx, size_t size)
 {
     void *elem;
 
@@ -80,11 +80,11 @@ void array_destroy(struct array *a);
 rstatus_t array_init(struct array *a, uint32_t n, size_t size);
 void array_deinit(struct array *a);
 
-uint32_t array_idx(struct array *a, void *elem);
+uint32_t array_idx(const struct array *a, const void *elem);
 void *array_push(struct array *a);
 void *array_pop(struct array *a);
-void *array_top(struct array *a);
-void *array_get(struct array *a, uint32_t idx);
+void *array_top(const struct array *a);
+void *array_get(const struct array *a, uint32_t idx);
 void array_swap(struct array *a, struct array *b);
 void array_sort(struct array *a, array_compare_t compare);
 rstatus_t array_each(struct array *a, array_each_t func, void *data);

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -298,7 +298,6 @@ conf_pool_each_transform(void *elem, void *data)
     sp->nserver_continuum = 0;
     sp->continuum = NULL;
     sp->nlive_server = 0;
-    sp->next_rebuild = 0LL;
     sp->next_sentinel_connect = 0LL;
     sp->sentinel_idx = 0;
 

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -505,7 +505,7 @@ conf_rewrite(struct context *ctx)
         conf_write_or_fail(fh, "  server_retry_timeout: %d",
                   cp->server_retry_timeout);
         conf_write_or_fail(fh, "  server_failure_limit: %d",
-                  cp->server_failure_limit);
+                  cp->unused_server_failure_limit);
 
         nserver = array_n(&cp->server);
         conf_write_or_fail(fh, "  servers:");

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -104,7 +104,7 @@ static struct command conf_commands[] = {
 
     { string("server_failure_limit"),
       conf_set_num,
-      offsetof(struct conf_pool, server_failure_limit) },
+      offsetof(struct conf_pool, unused_server_failure_limit) },
 
     { string("servers"),
       conf_add_server,
@@ -217,7 +217,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
     cp->auto_eject_hosts = CONF_UNSET_NUM;
     cp->server_connections = CONF_UNSET_NUM;
     cp->server_retry_timeout = CONF_UNSET_NUM;
-    cp->server_failure_limit = CONF_UNSET_NUM;
+    cp->unused_server_failure_limit = CONF_UNSET_NUM;
 
     array_null(&cp->server);
 
@@ -326,7 +326,6 @@ conf_pool_each_transform(void *elem, void *data)
     sp->client_connections = (uint32_t)cp->client_connections;
     sp->server_connections = (uint32_t)cp->server_connections;
     sp->server_retry_timeout = (int64_t)cp->server_retry_timeout * 1000LL;
-    sp->server_failure_limit = (uint32_t)cp->server_failure_limit;
     sp->auto_eject_hosts = cp->auto_eject_hosts ? 1 : 0;
     sp->preconnect = cp->preconnect ? 1 : 0;
 
@@ -385,8 +384,6 @@ conf_dump(struct conf *cf)
                   cp->server_connections);
         log_debug(LOG_VVERB, "  server_retry_timeout: %d",
                   cp->server_retry_timeout);
-        log_debug(LOG_VVERB, "  server_failure_limit: %d",
-                  cp->server_failure_limit);
         if (cp->failover_name.len != 0) {
           log_debug(LOG_VVERB, "  failover: \"%.*s\"", cp->failover_name.len, cp->failover_name.data);
         } else {
@@ -1525,8 +1522,8 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
         cp->server_retry_timeout = CONF_DEFAULT_SERVER_RETRY_TIMEOUT;
     }
 
-    if (cp->server_failure_limit == CONF_UNSET_NUM) {
-        cp->server_failure_limit = CONF_DEFAULT_SERVER_FAILURE_LIMIT;
+    if (cp->unused_server_failure_limit == CONF_UNSET_NUM) {
+        cp->unused_server_failure_limit = CONF_DEFAULT_SERVER_FAILURE_LIMIT;
     }
 
     if (!cp->redis && cp->redis_auth.len > 0) {

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -95,7 +95,7 @@ struct conf_pool {
     int                auto_eject_hosts;      /* auto_eject_hosts: */
     int                server_connections;    /* server_connections: */
     int                server_retry_timeout;  /* server_retry_timeout: in msec */
-    int                server_failure_limit;  /* server_failure_limit: */
+    int                unused_server_failure_limit;  /* server_failure_limit: */
     struct array       server;                /* servers: conf_server[] */
     struct string      failover_name;         /* failover pool name */
     struct array       sentinel;              /* sentinels: conf_server[] */

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -158,6 +158,7 @@ _conn_get(void)
     conn->done = 0;
     conn->redis = 0;
     conn->authenticated = 0;
+    conn->sent_heartbeat = 0;
 
     conn->status = CONN_DISCONNECTED;
 

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -329,7 +329,7 @@ conn_put(struct conn *conn)
 void
 conn_init(void)
 {
-    log_debug(LOG_DEBUG, "conn size %d", sizeof(struct conn));
+    log_debug(LOG_DEBUG, "conn size %ld", sizeof(struct conn));
     nfree_connq = 0;
     TAILQ_INIT(&free_connq);
 }

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -99,6 +99,7 @@ struct conn {
     unsigned            done:1;          /* done? aka close? */
     unsigned            redis:1;         /* redis? */
     unsigned            authenticated:1; /* authenticated? */
+    unsigned            sent_heartbeat:1; /* sent a heartbeat already? */
 
     conn_status_t       status;          /* conn status, just used for sentinel at present */
 };

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -307,6 +307,8 @@ retry_connection(struct context *ctx)
     rstatus_t status;
 
     /* Alternate between two lists of failed servers (to only retry a given server once here?) */
+    /* add_failed_server() has a check to ensure there are no duplicates, which is useful if connecting */
+    /* attempts are slow or to make the state machine for reconnecting easier to reason about. */
     servers = ctx->fails;
     idx = (ctx->failed_idx == 0) ? 1 : 0;
 

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -296,6 +296,7 @@ core_error(struct context *ctx, struct conn *conn)
 }
 
 /* Try to re-establish any failed connections to servers once the retry timeout has elapsed for a server. */
+/* This is periodically called from core_timeout */
 static void
 retry_connection(struct context *ctx)
 {
@@ -331,6 +332,10 @@ retry_connection(struct context *ctx)
         } else {
             add_failed_server(ctx, server);
         }
+        /* Postcondition: A connection in this server is either */
+        /* 1. already connected */
+        /* 2. reconnecting, or */
+        /* 3. added to the opposite failed server list to retry later */
     }
 }
 

--- a/src/nc_response.c
+++ b/src/nc_response.c
@@ -210,6 +210,7 @@ rsp_filter(struct context *ctx, struct conn *conn, struct msg *msg)
         if (pmsg->heartbeat) {
             /* This is the response of a heartbeat message - put the server in state FAIL_STATUS_NORMAL to indicate that this should be used instead of the failover pool */
             struct conn *c_conn;
+            ASSERT(conn->sent_heartbeat);
 
             c_conn = pmsg->owner;
             server_restore_from_heartbeat(server, c_conn);

--- a/src/nc_response.c
+++ b/src/nc_response.c
@@ -208,7 +208,11 @@ rsp_filter(struct context *ctx, struct conn *conn, struct msg *msg)
 
     if (pmsg->swallow) {
         if (pmsg->heartbeat) {
-            /* This is the response of a heartbeat message - put the server in state FAIL_STATUS_NORMAL to indicate that this should be used instead of the failover pool */
+            /* This is a correctly parsed response to a heartbeat message - put the server in state FAIL_STATUS_NORMAL to indicate that this should be used instead of the failover pool */
+            /* It is expected that either: */
+            /* 1. This happens: A correctly parsed response is received for the heartbeat message */
+            /* 2. There is a protocol error and the connection is closed and added to the failed server list to try again */
+            /* 3. There is a timeout and the connection is closed and added to the failed server list to try again */
             struct conn *c_conn;
             ASSERT(conn->sent_heartbeat);
 

--- a/src/nc_sentinel.c
+++ b/src/nc_sentinel.c
@@ -142,7 +142,6 @@ sentinel_proc_sentinel_info(struct context *ctx, struct server *sentinel, struct
     struct string const_sentinel_masters_prefix;
     struct string const_sentinel_key_prefix;
     struct string const_master_prefix;
-    struct string const_server_key;
     struct string const_name_key;
     struct string const_address_key;
     struct string const_status_key;

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -1358,15 +1358,16 @@ server_reconnect(struct context *ctx, struct server *server)
     return status;
 }
 
+/* Add a server to the list of failed servers to retry after processing remaining events for that server (and other servers). */
 void
 add_failed_server(struct context *ctx, struct server *server)
 {
     struct server **pserver;
-    uint32_t i, n;
+    uint32_t i;
 
     server->fail = FAIL_STATUS_ERR_TRY_CONNECT;
     for (i = 0; i < array_n(ctx->fails); i++) {
-        struct server *other = *(struct server **)array_get(ctx->fails, i);
+        struct server *other = *array_get_known_type(ctx->fails, i, struct server*);
         if (other == server) {
             /* Don't add a server to fails if it's already in the array. This is actually common when a server is rejecting connections. */
             log_debug(LOG_DEBUG, "Filtering out redundant attempt to reconnect to server %.*s in pool %.*s",

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -1396,7 +1396,6 @@ void
 server_restore_from_heartbeat(struct server *server, struct conn *conn)
 {
     struct server_pool *pool;
-    rstatus_t status;
 
     conn->unref(conn);
     conn_put(conn);
@@ -1410,15 +1409,15 @@ server_restore_from_heartbeat(struct server *server, struct conn *conn)
      * now that it's healthy.
      */
     if (pool->auto_eject_hosts) {
-        status = server_pool_run(pool);
-    }
-    if (status == NC_OK) {
-        log_debug(LOG_NOTICE, "updating pool %"PRIu32" '%.*s',"
-                "restored server '%.*s'", pool->idx,
-                pool->name.len, pool->name.data,
-                server->name.len, server->name.data);
-    } else {
-        log_error("updating pool %"PRIu32" '%.*s' failed: %s", pool->idx,
-                pool->name.len, pool->name.data, strerror(errno));
+        rstatus_t status = server_pool_run(pool);
+        if (status == NC_OK) {
+            log_debug(LOG_NOTICE, "updating pool %"PRIu32" '%.*s',"
+                    "restored server '%.*s'", pool->idx,
+                    pool->name.len, pool->name.data,
+                    server->name.len, server->name.data);
+        } else {
+            log_error("updating pool %"PRIu32" '%.*s' failed: %s", pool->idx,
+                    pool->name.len, pool->name.data, strerror(errno));
+        }
     }
 }

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -348,7 +348,7 @@ server_failure(struct context *ctx, struct server *server)
     rstatus_t status;
     bool is_reconnect;
 
-    /* sentinel do not need eject */
+    /* redis sentinels do not need eject - they have different reconnection logic */
     if (server->sentinel) {
         return;
     }
@@ -358,6 +358,7 @@ server_failure(struct context *ctx, struct server *server)
 
     now = nc_usec_now();
     if (now < 0) {
+        /* In practice, this shouldn't be reached - gettimeofday should never fail */
         return;
     }
 
@@ -1343,6 +1344,7 @@ server_reconnect(struct context *ctx, struct server *server)
 
     conn = server_conn(server);
     if (conn == NULL) {
+        log_error("server_conn failed on server_reconnect - this should only happen if out of memory");
         return NC_ERROR;
     }
 

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -111,7 +111,6 @@ struct server_pool {
     uint32_t           nserver_continuum;    /* # servers - live and dead on continuum (const) */
     struct continuum   *continuum;           /* continuum */
     uint32_t           nlive_server;         /* # live server */
-    int64_t            next_rebuild;         /* next distribution rebuild time in usec */
     int64_t            next_sentinel_connect;/* next reconnect sentinel time in usec */
     uint32_t           sentinel_idx;         /* the connected sentinel's idx */
 

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -129,7 +129,6 @@ struct server_pool {
     uint32_t           client_connections;   /* maximum # client connection */
     uint32_t           server_connections;   /* maximum # server connection */
     int64_t            server_retry_timeout; /* server retry timeout in usec */
-    uint32_t           server_failure_limit; /* server failure limit */
     struct string      redis_auth;           /* redis_auth password (matches requirepass on redis) */
     unsigned           require_auth;         /* require_auth? */
     struct string      failover_name;        /* failover pool name */

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -405,7 +405,10 @@ stats_create_buf(struct stats *st)
                 size += key_value_extra;
             }
 
-            // The possible statuses are "reconnecting", "heartbeat", "normal", and "unknown" - "reconnecting" is the longest one
+            /*
+             * The possible statuses are "reconnecting", "heartbeat", "normal",
+             * and "unknown" - "reconnecting" is the longest one
+             */
             size += sizeof("\"connection_status\":\"reconnecting\", ") - 1;
         }
     }
@@ -769,9 +772,15 @@ stats_make_rsp(struct stats *st)
                 return status;
             }
 
-            /* This may be prone to a race condition, but at worst should return "unknown"? */
-            /* Read the status directly to aid in debugging issues with the heartbeat patch. */
-            /* NOTE: If new statuses are added, stats_create_buf should be updated with the new longest length */
+            /*
+             * This may be prone to a race condition,
+             * but at worst should return "unknown"?
+             * Read the status directly to aid in debugging issues with the
+             * heartbeat patch.
+             *
+             * NOTE: If new statuses are added,
+             * stats_create_buf should be updated with the new longest length
+             */
             uint32_t fail = sts->server->fail;
             const char *status_string = "unknown";
             if (fail == FAIL_STATUS_NORMAL) {
@@ -781,7 +790,8 @@ stats_make_rsp(struct stats *st)
             } else if (fail == FAIL_STATUS_ERR_TRY_HEARTBEAT)  {
                 status_string = "heartbeat";
             }
-            status = stats_add_hardcoded_string(st, "connection_status", status_string);
+            status = stats_add_hardcoded_string(st, "connection_status",
+                                                status_string);
             if (status != NC_OK) {
                 return status;
             }

--- a/src/nc_stats.h
+++ b/src/nc_stats.h
@@ -72,6 +72,7 @@ struct stats_metric {
 struct stats_server {
     struct string name;   /* server name (ref) */
     struct array  metric; /* stats_metric[] for server codec */
+    const struct server *server; /* read-only server pointer for inspecting current state. */
 };
 
 struct stats_pool {


### PR DESCRIPTION
Problem

Heartbeat patches can result in a server getting in a state where a spurious timeout
leads to it being evicted from the pool

Solution

Avoid sending more than one heartbeat per connection, and avoid reconnecting more than once per event loop 
in order to make heartbeat reconnection logic easier to reason about.

Add more visibility into the server status and pool updates so that
1. It can be fixed if the issue continues to occur
2. Alerting checks can be added if nutcracker instances do not recover automatically, or if the set of failing hosts is different on different nutcracker instances

